### PR TITLE
Check for install reason before opening options

### DIFF
--- a/src/control/background.js
+++ b/src/control/background.js
@@ -7,7 +7,7 @@ browser.runtime.onInstalled.addListener(async (details) => {
     browser.browserAction.setBadgeTextColor({ color: '#20163d' });
     browser.browserAction.setBadgeBackgroundColor({ color: '#42b0ff' });
   }
-  if(details.reason === "installed") {
+  if(details.reason === "install") {
     browser.tabs.create({ url: 'ui/menu.html' });
   }
 });

--- a/src/control/background.js
+++ b/src/control/background.js
@@ -1,9 +1,13 @@
-browser.runtime.onInstalled.addListener(async () => {
+browser.runtime.onInstalled.addListener(async (details) => {
   await browser.tabs.query({ url: '*://*.cohost.org/*' }).then(async tabs => {
     tabs.forEach(tab => browser.tabs.reload(tab.id));
   });
-  browser.browserAction.setBadgeText({ text: '+' });
-  browser.browserAction.setBadgeTextColor({ color: '#20163d' });
-  browser.browserAction.setBadgeBackgroundColor({ color: '#42b0ff' });
-  browser.tabs.create({ url: 'ui/menu.html' });
+  if(details.reason === "update") {
+    browser.browserAction.setBadgeText({ text: '+' });
+    browser.browserAction.setBadgeTextColor({ color: '#20163d' });
+    browser.browserAction.setBadgeBackgroundColor({ color: '#42b0ff' });
+  }
+  if(details.reason === "installed") {
+    browser.tabs.create({ url: 'ui/menu.html' });
+  }
 });


### PR DESCRIPTION
Not a fan of extensions opening tabs when they're updated since it ends up causing an interruption.

This PR changes it so that the update badge only appears when the extension updates and the options tab only opens when the extension is installed, essentially partially reverting fcf0a577ebdfdfacbf384b97c4efc41710813e4a.